### PR TITLE
Add link to Ben's Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We have adopted a [code of conduct](https://github.com/si2-urssi/winterschool/bl
 
 [Andy Loftus](https://github.com/andylytical)
 
-Ben Galewsky
+[Ben Galewsky](https://github.com/BenGalewsky)
 
 [Leah Fulmer](https://github.com/lfulmer)
 


### PR DESCRIPTION
README was missing link to Ben's GitHub account. Updated